### PR TITLE
Swap notification title and body

### DIFF
--- a/src/module/e_mod_main.c
+++ b/src/module/e_mod_main.c
@@ -140,7 +140,7 @@ _notify(const int val)
    else
      icon = "audio-volume-high";
 
-   snprintf(cmd, 200, "notify-send --expire-time=1500 --icon=%s 'Level %d' 'Volume Changed.'", icon, val);
+   snprintf(cmd, 200, "notify-send --expire-time=1500 --icon=%s 'Volume Changed.' 'Level %d'", icon, val);
 
    ecore_init();
    ecore_exe_run(cmd, NULL);


### PR DESCRIPTION
Changing the notify-send title every time volume changes spawns new notification message, which looks ugly. If notification status is updated on the other hand, it will appear in the same notification.